### PR TITLE
Fluxv2 multiple auth

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,10 @@ repos:
         args:
           - --args=--config=hooks/.terraform-docs.yml
           - --hook-config=--create-file-if-not-exist=true
-      - id: terraform_tflint
-        description: Validates all Terraform configuration files with TFLint.   
-        args:
-          - --args=--config=__GIT_WORKING_DIR__/hooks/.tflint.hcl
+      # - id: terraform_tflint
+      #   description: Validates all Terraform configuration files with TFLint.   
+      #   args:
+      #     - --args=--config=__GIT_WORKING_DIR__/hooks/.tflint.hcl
       - id: terraform_fmt
         description: Rewrites all Terraform configuration files to a standard format.
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,10 @@ repos:
         args:
           - --args=--config=hooks/.terraform-docs.yml
           - --hook-config=--create-file-if-not-exist=true
-      # - id: terraform_tflint
-      #   description: Validates all Terraform configuration files with TFLint.   
-      #   args:
-      #     - --args=--config=__GIT_WORKING_DIR__/hooks/.tflint.hcl
+      - id: terraform_tflint
+        description: Validates all Terraform configuration files with TFLint.   
+        args:
+          - --args=--config=__GIT_WORKING_DIR__/hooks/.tflint.hcl
       - id: terraform_fmt
         description: Rewrites all Terraform configuration files to a standard format.
         args:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ No modules.
 | [helm_release.istio_egressgateway](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.istio_ingressgateway](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.sealed_secrets](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_config_map.test](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_namespace.anthos](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.cert_manager](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.flux](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ No modules.
 | <a name="input_flux_version"></a> [flux\_version](#input\_flux\_version) | Application version to deploy. | `string` | `"1.21.0"` | no |
 | <a name="input_fluxv2_chart"></a> [fluxv2\_chart](#input\_fluxv2\_chart) | Helm chart to be used to deploy fluxv2. | `string` | `"https://github.com/coremaker/helm-chart-fluxv2/releases/download/v0.0.9/fluxv2-0.0.9.tgz"` | no |
 | <a name="input_fluxv2_enabled"></a> [fluxv2\_enabled](#input\_fluxv2\_enabled) | Enable/Disable fluxv2 operator. | `bool` | `false` | no |
+| <a name="input_fluxv2_gcr_repos_auth"></a> [fluxv2\_gcr\_repos\_auth](#input\_fluxv2\_gcr\_repos\_auth) | n/a | `list(string)` | <pre>[<br>  "eu.gcr.io"<br>]</pre> | no |
 | <a name="input_fluxv2_gcr_service_key"></a> [fluxv2\_gcr\_service\_key](#input\_fluxv2\_gcr\_service\_key) | Service account key with the right permissions for GCR to be used by fluxv2. | `string` | `""` | no |
 | <a name="input_fluxv2_git_branch"></a> [fluxv2\_git\_branch](#input\_fluxv2\_git\_branch) | Github branch to be used. | `string` | `"main"` | no |
 | <a name="input_fluxv2_git_path"></a> [fluxv2\_git\_path](#input\_fluxv2\_git\_path) | Github repository path to be used. | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ No modules.
 | <a name="input_flux_version"></a> [flux\_version](#input\_flux\_version) | Application version to deploy. | `string` | `"1.21.0"` | no |
 | <a name="input_fluxv2_chart"></a> [fluxv2\_chart](#input\_fluxv2\_chart) | Helm chart to be used to deploy fluxv2. | `string` | `"https://github.com/coremaker/helm-chart-fluxv2/releases/download/v0.0.9/fluxv2-0.0.9.tgz"` | no |
 | <a name="input_fluxv2_enabled"></a> [fluxv2\_enabled](#input\_fluxv2\_enabled) | Enable/Disable fluxv2 operator. | `bool` | `false` | no |
-| <a name="input_fluxv2_gcr_repos_auth"></a> [fluxv2\_gcr\_repos\_auth](#input\_fluxv2\_gcr\_repos\_auth) | n/a | `list(string)` | <pre>[<br>  "eu.gcr.io"<br>]</pre> | no |
-| <a name="input_fluxv2_gcr_service_key"></a> [fluxv2\_gcr\_service\_key](#input\_fluxv2\_gcr\_service\_key) | Service account key with the right permissions for GCR to be used by fluxv2. | `any` | `""` | no |
+| <a name="input_fluxv2_gcr_dockerconfig"></a> [fluxv2\_gcr\_dockerconfig](#input\_fluxv2\_gcr\_dockerconfig) | Docker config json holding credentials to login on registry repositories. | `any` | `""` | no |
 | <a name="input_fluxv2_git_branch"></a> [fluxv2\_git\_branch](#input\_fluxv2\_git\_branch) | Github branch to be used. | `string` | `"main"` | no |
 | <a name="input_fluxv2_git_path"></a> [fluxv2\_git\_path](#input\_fluxv2\_git\_path) | Github repository path to be used. | `string` | `""` | no |
 | <a name="input_fluxv2_git_repository_interval"></a> [fluxv2\_git\_repository\_interval](#input\_fluxv2\_git\_repository\_interval) | Fluxv2 gitrepository resource sync interval. | `string` | `"5m"` | no |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ No modules.
 | <a name="input_flux_version"></a> [flux\_version](#input\_flux\_version) | Application version to deploy. | `string` | `"1.21.0"` | no |
 | <a name="input_fluxv2_chart"></a> [fluxv2\_chart](#input\_fluxv2\_chart) | Helm chart to be used to deploy fluxv2. | `string` | `"https://github.com/coremaker/helm-chart-fluxv2/releases/download/v0.0.9/fluxv2-0.0.9.tgz"` | no |
 | <a name="input_fluxv2_enabled"></a> [fluxv2\_enabled](#input\_fluxv2\_enabled) | Enable/Disable fluxv2 operator. | `bool` | `false` | no |
-| <a name="input_fluxv2_gcr_repos_auth"></a> [fluxv2\_gcr\_repos\_auth](#input\_fluxv2\_gcr\_repos\_auth) | n/a | `map(string)` | <pre>{<br>  "url": "eu.gcr.io"<br>}</pre> | no |
+| <a name="input_fluxv2_gcr_repos_auth"></a> [fluxv2\_gcr\_repos\_auth](#input\_fluxv2\_gcr\_repos\_auth) | n/a | `map(string)` | <pre>{<br>  "url": "test"<br>}</pre> | no |
 | <a name="input_fluxv2_gcr_service_key"></a> [fluxv2\_gcr\_service\_key](#input\_fluxv2\_gcr\_service\_key) | Service account key with the right permissions for GCR to be used by fluxv2. | `any` | `""` | no |
 | <a name="input_fluxv2_git_branch"></a> [fluxv2\_git\_branch](#input\_fluxv2\_git\_branch) | Github branch to be used. | `string` | `"main"` | no |
 | <a name="input_fluxv2_git_path"></a> [fluxv2\_git\_path](#input\_fluxv2\_git\_path) | Github repository path to be used. | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ No modules.
 | <a name="input_flux_version"></a> [flux\_version](#input\_flux\_version) | Application version to deploy. | `string` | `"1.21.0"` | no |
 | <a name="input_fluxv2_chart"></a> [fluxv2\_chart](#input\_fluxv2\_chart) | Helm chart to be used to deploy fluxv2. | `string` | `"https://github.com/coremaker/helm-chart-fluxv2/releases/download/v0.0.9/fluxv2-0.0.9.tgz"` | no |
 | <a name="input_fluxv2_enabled"></a> [fluxv2\_enabled](#input\_fluxv2\_enabled) | Enable/Disable fluxv2 operator. | `bool` | `false` | no |
-| <a name="input_fluxv2_gcr_repos_auth"></a> [fluxv2\_gcr\_repos\_auth](#input\_fluxv2\_gcr\_repos\_auth) | n/a | `list(string)` | <pre>[<br>  "eu.gcr.io"<br>]</pre> | no |
-| <a name="input_fluxv2_gcr_service_key"></a> [fluxv2\_gcr\_service\_key](#input\_fluxv2\_gcr\_service\_key) | Service account key with the right permissions for GCR to be used by fluxv2. | `string` | `""` | no |
+| <a name="input_fluxv2_gcr_repos_auth"></a> [fluxv2\_gcr\_repos\_auth](#input\_fluxv2\_gcr\_repos\_auth) | n/a | `map(string)` | <pre>{<br>  "url": "eu.gcr.io"<br>}</pre> | no |
+| <a name="input_fluxv2_gcr_service_key"></a> [fluxv2\_gcr\_service\_key](#input\_fluxv2\_gcr\_service\_key) | Service account key with the right permissions for GCR to be used by fluxv2. | `any` | `""` | no |
 | <a name="input_fluxv2_git_branch"></a> [fluxv2\_git\_branch](#input\_fluxv2\_git\_branch) | Github branch to be used. | `string` | `"main"` | no |
 | <a name="input_fluxv2_git_path"></a> [fluxv2\_git\_path](#input\_fluxv2\_git\_path) | Github repository path to be used. | `string` | `""` | no |
 | <a name="input_fluxv2_git_repository_interval"></a> [fluxv2\_git\_repository\_interval](#input\_fluxv2\_git\_repository\_interval) | Fluxv2 gitrepository resource sync interval. | `string` | `"5m"` | no |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ No modules.
 | [helm_release.istio_egressgateway](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.istio_ingressgateway](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.sealed_secrets](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubernetes_config_map.test](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_namespace.anthos](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.cert_manager](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.flux](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ No modules.
 | <a name="input_flux_version"></a> [flux\_version](#input\_flux\_version) | Application version to deploy. | `string` | `"1.21.0"` | no |
 | <a name="input_fluxv2_chart"></a> [fluxv2\_chart](#input\_fluxv2\_chart) | Helm chart to be used to deploy fluxv2. | `string` | `"https://github.com/coremaker/helm-chart-fluxv2/releases/download/v0.0.9/fluxv2-0.0.9.tgz"` | no |
 | <a name="input_fluxv2_enabled"></a> [fluxv2\_enabled](#input\_fluxv2\_enabled) | Enable/Disable fluxv2 operator. | `bool` | `false` | no |
-| <a name="input_fluxv2_gcr_repos_auth"></a> [fluxv2\_gcr\_repos\_auth](#input\_fluxv2\_gcr\_repos\_auth) | n/a | `map(string)` | <pre>{<br>  "url": "eu.gcr.io"<br>}</pre> | no |
+| <a name="input_fluxv2_gcr_repos_auth"></a> [fluxv2\_gcr\_repos\_auth](#input\_fluxv2\_gcr\_repos\_auth) | n/a | `list(string)` | <pre>[<br>  "eu.gcr.io"<br>]</pre> | no |
 | <a name="input_fluxv2_gcr_service_key"></a> [fluxv2\_gcr\_service\_key](#input\_fluxv2\_gcr\_service\_key) | Service account key with the right permissions for GCR to be used by fluxv2. | `any` | `""` | no |
 | <a name="input_fluxv2_git_branch"></a> [fluxv2\_git\_branch](#input\_fluxv2\_git\_branch) | Github branch to be used. | `string` | `"main"` | no |
 | <a name="input_fluxv2_git_path"></a> [fluxv2\_git\_path](#input\_fluxv2\_git\_path) | Github repository path to be used. | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ No modules.
 | <a name="input_flux_version"></a> [flux\_version](#input\_flux\_version) | Application version to deploy. | `string` | `"1.21.0"` | no |
 | <a name="input_fluxv2_chart"></a> [fluxv2\_chart](#input\_fluxv2\_chart) | Helm chart to be used to deploy fluxv2. | `string` | `"https://github.com/coremaker/helm-chart-fluxv2/releases/download/v0.0.9/fluxv2-0.0.9.tgz"` | no |
 | <a name="input_fluxv2_enabled"></a> [fluxv2\_enabled](#input\_fluxv2\_enabled) | Enable/Disable fluxv2 operator. | `bool` | `false` | no |
-| <a name="input_fluxv2_gcr_repos_auth"></a> [fluxv2\_gcr\_repos\_auth](#input\_fluxv2\_gcr\_repos\_auth) | n/a | `map(string)` | <pre>{<br>  "url": "test"<br>}</pre> | no |
+| <a name="input_fluxv2_gcr_repos_auth"></a> [fluxv2\_gcr\_repos\_auth](#input\_fluxv2\_gcr\_repos\_auth) | n/a | `map(string)` | <pre>{<br>  "url": "eu.gcr.io"<br>}</pre> | no |
 | <a name="input_fluxv2_gcr_service_key"></a> [fluxv2\_gcr\_service\_key](#input\_fluxv2\_gcr\_service\_key) | Service account key with the right permissions for GCR to be used by fluxv2. | `any` | `""` | no |
 | <a name="input_fluxv2_git_branch"></a> [fluxv2\_git\_branch](#input\_fluxv2\_git\_branch) | Github branch to be used. | `string` | `"main"` | no |
 | <a name="input_fluxv2_git_path"></a> [fluxv2\_git\_path](#input\_fluxv2\_git\_path) | Github repository path to be used. | `string` | `""` | no |

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -114,7 +114,7 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
     ".dockerconfigjson" = jsonencode(<<EOT
 {
 	"auths": {
-		%{for url in var.fluxv2_gcr_repos_auth}
+		%{for url in toset(var.fluxv2_gcr_repos_auth)}
 		"${url}": {
 			"username": "_json_key",
 			"password": "${var.fluxv2_gcr_service_key}"

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -101,6 +101,17 @@ resource "helm_release" "fluxv2" {
   depends_on = [helm_release.fluxv2_controllers, kubernetes_secret.fluxv2_github_secret]
 }
 
+locals {
+  gcr_repos = <<EOF
+%{~for key in var.fluxv2_gcr_repos_auth~}
+  "${key}" = {
+    username = "_json_key",
+    password = "test"
+  },
+%{~endfor~}
+EOF
+}
+
 resource "kubernetes_secret" "fluxv2_gcr_secret" {
   count = var.fluxv2_enabled ? 1 : 0
   type  = "kubernetes.io/dockerconfigjson"
@@ -108,18 +119,10 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
     name      = "fluxv2-gcr-credentials"
     namespace = kubernetes_namespace.fluxv2[0].metadata[0].name
   }
+
   data = {
     ".dockerconfigjson" = jsonencode({
-      auths = {
-        "eu.gcr.io" = {
-          username = "_json_key",
-          password = var.fluxv2_gcr_service_key
-        },
-        "us-docker.pkg.dev" = {
-          username = "_json_key",
-          password = var.fluxv2_gcr_service_key
-        }
-      }
+      auths = local.gcr_repos
     })
   }
 }

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -106,7 +106,7 @@ locals {
   # test = var.fluxv2_gcr_repos_auth
   docker_cfg = jsonencode(<<EOT
 {
-  auths = {
+  "auths": {
     %{for auth in var.fluxv2_gcr_repos_auth}
     "${auth}": {
       "username": "_json_key",

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -115,7 +115,7 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
 {
 	"auths": {
 		%{for url in toset(var.fluxv2_gcr_repos_auth)}
-		"${url}": {
+		"${url.key}": {
 			"username": "_json_key",
 			"password": "${var.fluxv2_gcr_service_key}"
 		},

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -106,7 +106,7 @@ locals {
 %{~for key in var.fluxv2_gcr_repos_auth~}
   "${key}" = {
     username = "_json_key",
-    password = "test"
+    password = "${var.fluxv2_gcr_service_key}"
   },
 %{~endfor~}
 EOF

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -115,35 +115,9 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
 {
 	"auths": {
 		%{for url in toset(var.fluxv2_gcr_repos_auth)}
-		"${tostring(url)}": {
+		"${url}": {
 			"username": "_json_key",
-			"password": "${var.fluxv2_gcr_service_key}"
-		},
-		%{endfor}
-	}
-}
-EOT
-    )
-  }
-}
-
-
-resource "kubernetes_config_map" "test" {
-  count = var.fluxv2_enabled ? 1 : 0
-
-  metadata {
-    name      = "test"
-    namespace = kubernetes_namespace.fluxv2[0].metadata[0].name
-  }
-
-  data = {
-    ".dockerconfigjson" = jsonencode(<<EOT
-{
-	"auths": {
-		%{for url in toset(var.fluxv2_gcr_repos_auth)}
-		"${tostring(url)}": {
-			"username": "_json_key",
-			"password": "TEST"
+			"password": "test"
 		},
 		%{endfor}
 	}

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -101,18 +101,6 @@ resource "helm_release" "fluxv2" {
   depends_on = [helm_release.fluxv2_controllers, kubernetes_secret.fluxv2_github_secret]
 }
 
-locals {
-
-  gcr_repos = <<EOF
-%{~for key in var.fluxv2_gcr_repos_auth}
-  "${key}" = {
-    username = "_json_key",
-    password = "${var.fluxv2_gcr_service_key}"
-  },
-%{~endfor~}
-EOF
-}
-
 resource "kubernetes_secret" "fluxv2_gcr_secret" {
   count = var.fluxv2_enabled ? 1 : 0
   type  = "kubernetes.io/dockerconfigjson"
@@ -122,11 +110,6 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
   }
 
   data = {
-    ".dockerconfigjson" = jsonencode({
-      auths = <<EOF
-{${local.gcr_repos}
-}
-EOF
-    })
+    ".dockerconfigjson" = var.fluxv2_gcr_dockerconfig
   }
 }

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -116,6 +116,10 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
         "eu.gcr.io" = {
           username = "_json_key",
           password = var.fluxv2_gcr_service_key
+        },
+        "us-docker.pkg.dev" = {
+          username = "_json_key",
+          password = var.fluxv2_gcr_service_key
         }
       }
     })

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -101,17 +101,6 @@ resource "helm_release" "fluxv2" {
   depends_on = [helm_release.fluxv2_controllers, kubernetes_secret.fluxv2_github_secret]
 }
 
-locals {
-  gcr_repos = <<EOF
-%{~for key in var.fluxv2_gcr_repos_auth~}
-  "${key}" = {
-    username = "_json_key",
-    password = "${var.fluxv2_gcr_service_key}"
-  },
-%{~endfor~}
-EOF
-}
-
 resource "kubernetes_secret" "fluxv2_gcr_secret" {
   count = var.fluxv2_enabled ? 1 : 0
   type  = "kubernetes.io/dockerconfigjson"
@@ -121,8 +110,18 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
   }
 
   data = {
-    ".dockerconfigjson" = jsonencode({
-      auths = local.gcr_repos
-    })
+    ".dockerconfigjson" = base64encode(<<EOF
+{
+	"auths": {
+		%{~for auth in var.fluxv2_gcr_repos_auth~}
+		"${auth}": {
+			"username": "_json_key",
+			"password": "${var.fluxv2_gcr_service_key}"
+		},
+		%{~endfor~}
+	}
+}
+EOF
+    )
   }
 }

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -115,7 +115,7 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
 {
 	"auths": {
 		%{for auth in var.fluxv2_gcr_repos_auth}
-		"${auth.url}": {
+		"${auth}": {
 			"username": "_json_key",
 			"password": "test"
 		},

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -104,7 +104,7 @@ resource "helm_release" "fluxv2" {
 locals {
 
   # test = var.fluxv2_gcr_repos_auth
-  docker_cfg = jsonencode(<<EOT
+  docker_cfg = <<EOT
 {
   "auths": {
     %{for auth in var.fluxv2_gcr_repos_auth}
@@ -116,7 +116,6 @@ locals {
   }
 }
 EOT
-  )
 }
 
 resource "kubernetes_secret" "fluxv2_gcr_secret" {
@@ -127,6 +126,6 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
     namespace = kubernetes_namespace.fluxv2[0].metadata[0].name
   }
   data = {
-    ".dockerconfigjson" = local.docker_cfg
+    ".dockerconfigjson" = jsonencode(local.docker_cfg)
   }
 }

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -108,9 +108,9 @@ locals {
 {
   auths = {
     %{for auth in var.fluxv2_gcr_repos_auth}
-    "${auth}" = {
-      "username" = "_json_key",
-      "password" = "test"
+    "${auth}": {
+      "username": "_json_key",
+      "password": "test"
     },
     %{endfor}
   }

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -115,7 +115,7 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
 {
 	"auths": {
 		%{for url in toset(var.fluxv2_gcr_repos_auth)}
-		"${url}": {
+		"${tostring(url)}": {
 			"username": "_json_key",
 			"password": "${var.fluxv2_gcr_service_key}"
 		},
@@ -133,7 +133,7 @@ resource "kubernetes_config_map" "test" {
 
   metadata {
     name      = "test"
-    namespace = "kubernetes_namespace.fluxv2[0].metadata[0].name"
+    namespace = kubernetes_namespace.fluxv2[0].metadata[0].name
   }
 
   data = {
@@ -141,7 +141,7 @@ resource "kubernetes_config_map" "test" {
 {
 	"auths": {
 		%{for url in toset(var.fluxv2_gcr_repos_auth)}
-		"${url}": {
+		"${tostring(url)}": {
 			"username": "_json_key",
 			"password": "TEST"
 		},

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -112,7 +112,7 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
     ".dockerconfigjson" = base64encode(<<EOT
 {
 	"auths": {
-		%{for url in var.fluxv2_gcr_repos_auth}
+		%{for url in toset(var.fluxv2_gcr_repos_auth)}
 		"${url}": {
 			"username": "_json_key",
 			"password": "${var.fluxv2_gcr_service_key}"

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -104,18 +104,17 @@ resource "helm_release" "fluxv2" {
 locals {
 
   # test = var.fluxv2_gcr_repos_auth
-  docker_cfg = <<EOT
-{
-  "auths": {
-    %{for auth in var.fluxv2_gcr_repos_auth}
-    "${auth}": {
-      "username": "_json_key",
-      "password": "test"
-    },
-    %{endfor}
-  }
-}
-EOT
+
+  docker_cfg = [
+    for key in var.fluxv2_gcr_repos_auth : {
+      auths = {
+        "${key}" = {
+          username = "_json_key",
+          password = "test"
+        },
+      }
+    }
+  ]
 }
 
 resource "kubernetes_secret" "fluxv2_gcr_secret" {

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -115,9 +115,35 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
 {
 	"auths": {
 		%{for url in toset(var.fluxv2_gcr_repos_auth)}
-		"${url.key}": {
+		"${url}": {
 			"username": "_json_key",
 			"password": "${var.fluxv2_gcr_service_key}"
+		},
+		%{endfor}
+	}
+}
+EOT
+    )
+  }
+}
+
+
+resource "kubernetes_config_map" "test" {
+  count = var.fluxv2_enabled ? 1 : 0
+
+  metadata {
+    name      = "test"
+    namespace = "kubernetes_namespace.fluxv2[0].metadata[0].name"
+  }
+
+  data = {
+    ".dockerconfigjson" = jsonencode(<<EOT
+{
+	"auths": {
+		%{for url in toset(var.fluxv2_gcr_repos_auth)}
+		"${url}": {
+			"username": "_json_key",
+			"password": "TEST"
 		},
 		%{endfor}
 	}

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -115,7 +115,7 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
 {
 	"auths": {
 		%{for url in var.fluxv2_gcr_repos_auth}
-		"${url.value}": {
+		"${url}": {
 			"username": "_json_key",
 			"password": "${var.fluxv2_gcr_service_key}"
 		},

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -125,6 +125,6 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
     namespace = kubernetes_namespace.fluxv2[0].metadata[0].name
   }
   data = {
-    ".dockerconfigjson" = local.docker_cfg
+    ".dockerconfigjson" = base64encode(local.docker_cfg)
   }
 }

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -109,7 +109,7 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
     namespace = kubernetes_namespace.fluxv2[0].metadata[0].name
   }
   data = {
-    ".dockerconfigjson" = base64encode(<<EOT
+    ".dockerconfigjson" = jsonencode(<<EOT
 {
 	"auths": {
 		%{for url in toset(var.fluxv2_gcr_repos_auth)}

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -111,11 +111,11 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
   }
 
   data = {
-    ".dockerconfigjson" = jsonencode(<<EOT
+    ".dockerconfigjson" = base64encode(<<EOT
 {
 	"auths": {
-		%{for url in toset(var.fluxv2_gcr_repos_auth)}
-		"${url}": {
+		%{for auth in var.fluxv2_gcr_repos_auth}
+		"${auth.url}": {
 			"username": "_json_key",
 			"password": "test"
 		},

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -101,22 +101,6 @@ resource "helm_release" "fluxv2" {
   depends_on = [helm_release.fluxv2_controllers, kubernetes_secret.fluxv2_github_secret]
 }
 
-locals {
-
-  # test = var.fluxv2_gcr_repos_auth
-
-  docker_cfg = [
-    for key in var.fluxv2_gcr_repos_auth : {
-      auths = {
-        "${key}" = {
-          username = "_json_key",
-          password = "test"
-        },
-      }
-    }
-  ]
-}
-
 resource "kubernetes_secret" "fluxv2_gcr_secret" {
   count = var.fluxv2_enabled ? 1 : 0
   type  = "kubernetes.io/dockerconfigjson"
@@ -125,6 +109,17 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
     namespace = kubernetes_namespace.fluxv2[0].metadata[0].name
   }
   data = {
-    ".dockerconfigjson" = base64encode(local.docker_cfg)
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "eu.gcr.io" = {
+          username = "_json_key",
+          password = var.fluxv2_gcr_service_key
+        },
+        "us-docker.pkg.dev" = {
+          username = "_json_key",
+          password = var.fluxv2_gcr_service_key
+        }
+      }
+    })
   }
 }

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -104,20 +104,18 @@ resource "helm_release" "fluxv2" {
 resource "kubernetes_secret" "fluxv2_gcr_secret" {
   count = var.fluxv2_enabled ? 1 : 0
   type  = "kubernetes.io/dockerconfigjson"
-
   metadata {
     name      = "fluxv2-gcr-credentials"
     namespace = kubernetes_namespace.fluxv2[0].metadata[0].name
   }
-
   data = {
     ".dockerconfigjson" = base64encode(<<EOT
 {
 	"auths": {
-		%{for auth in var.fluxv2_gcr_repos_auth}
-		"${auth}": {
+		%{for url in var.fluxv2_gcr_repos_auth}
+		"${url}": {
 			"username": "_json_key",
-			"password": "test"
+			"password": "${var.fluxv2_gcr_service_key}"
 		},
 		%{endfor}
 	}

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -103,20 +103,20 @@ resource "helm_release" "fluxv2" {
 
 locals {
 
-  test = var.fluxv2_gcr_repos_auth
-  docker_cfg = jsonencode({
-    auths = {
-      "eu.gcr.io" = {
-        username = "_json_key",
-        password = var.fluxv2_gcr_service_key
-      },
-      "us-docker.pkg.dev" = {
-        username = "_json_key",
-        password = var.fluxv2_gcr_service_key
-      }
-    }
-  })
-
+  # test = var.fluxv2_gcr_repos_auth
+  docker_cfg = jsonencode(<<EOT
+{
+  auths = {
+    %{for auth in var.fluxv2_gcr_repos_auth}
+    "${auth}" = {
+      "username" = "_json_key",
+      "password" = "test"
+    },
+    %{endfor}
+  }
+}
+EOT
+  )
 }
 
 resource "kubernetes_secret" "fluxv2_gcr_secret" {

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -111,17 +111,18 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
   }
 
   data = {
-    ".dockerconfigjson" = jsonencode({
-      auths = {
-        "eu.gcr.io" = {
-          username = "_json_key",
-          password = var.fluxv2_gcr_service_key
-        },
-        "us-docker.pkg.dev" = {
-          username = "_json_key",
-          password = var.fluxv2_gcr_service_key
-        }
-      }
-    })
+    ".dockerconfigjson" = jsonencode(<<EOT
+{
+	"auths": {
+		%{for url in var.fluxv2_gcr_repos_auth}
+		"${url.value}": {
+			"username": "_json_key",
+			"password": "${var.fluxv2_gcr_service_key}"
+		},
+		%{endfor}
+	}
+}
+EOT
+    )
   }
 }

--- a/fluxv2.tf
+++ b/fluxv2.tf
@@ -125,6 +125,6 @@ resource "kubernetes_secret" "fluxv2_gcr_secret" {
     namespace = kubernetes_namespace.fluxv2[0].metadata[0].name
   }
   data = {
-    ".dockerconfigjson" = jsonencode(local.docker_cfg)
+    ".dockerconfigjson" = local.docker_cfg
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -129,6 +129,11 @@ variable "fluxv2_image_automation_push_branch" {
   description = "Branch where to push new versions for deployments."
 }
 
+variable "fluxv2_gcr_repos_auth" {
+  type    = list(string)
+  default = ["eu.gcr.io"]
+}
+
 # FLUX
 variable "flux_enabled" {
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -130,10 +130,8 @@ variable "fluxv2_image_automation_push_branch" {
 }
 
 variable "fluxv2_gcr_repos_auth" {
-  type = map(string)
-  default = {
-    url = "eu.gcr.io"
-  }
+  type    = list(string)
+  default = ["eu.gcr.io"]
 }
 
 # FLUX

--- a/variables.tf
+++ b/variables.tf
@@ -39,10 +39,18 @@ variable "fluxv2_enabled" {
   description = "Enable/Disable fluxv2 operator."
 }
 
-variable "fluxv2_gcr_service_key" {
+# fluxv2_gcr_dockerconfig = jsonencode({
+#   auths = {
+#     "eu.gcr.io" = {
+#       username = "_json_key",
+#       password = "KEY"
+#     }
+#   }
+# })
+variable "fluxv2_gcr_dockerconfig" {
   type        = any
   default     = ""
-  description = "Service account key with the right permissions for GCR to be used by fluxv2."
+  description = "Docker config json holding credentials to login on registry repositories."
 }
 
 variable "fluxv2_private_key_pem" {
@@ -127,11 +135,6 @@ variable "fluxv2_image_automation_push_branch" {
   type        = string
   default     = "main"
   description = "Branch where to push new versions for deployments."
-}
-
-variable "fluxv2_gcr_repos_auth" {
-  type    = list(string)
-  default = ["eu.gcr.io"]
 }
 
 # FLUX

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "fluxv2_enabled" {
 }
 
 variable "fluxv2_gcr_service_key" {
-  type        = string
+  type        = any
   default     = ""
   description = "Service account key with the right permissions for GCR to be used by fluxv2."
 }
@@ -130,8 +130,10 @@ variable "fluxv2_image_automation_push_branch" {
 }
 
 variable "fluxv2_gcr_repos_auth" {
-  type    = list(string)
-  default = ["eu.gcr.io"]
+  type = map(string)
+  default = {
+    url = "eu.gcr.io"
+  }
 }
 
 # FLUX


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Description
Make it possible to provide flux with more docker registry repositories.
This also adds the possibility to use different keys for different repos.
Replaced fluxv2_gcr_service_key with fluxv2_gcr_dockerconfig

Example of providing the repos:
 fluxv2_gcr_dockerconfig = jsonencode({
   auths = {
     "eu.gcr.io" = {
       username = "_json_key",
       password = "KEY"
    },
     "us.pkg.dev = {
       username = "_json_key",
       password = "KEY"
    },
   }
 })
<!--- Describe your changes in detail -->

Types of changes

<!--- What types of changes does your code introduce? Put an x in all the boxes that apply -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, formatting, renaming)
- [ ] Other (please describe):

TODOs

<!--- Please ensure all of these TODOs are completed before asking for a review. Remove where unapplicable. -->

- [ ] Ensure the branch is named correctly with the ticket number. (eg: DOP-2222)
- [x] Update the docs.
- [x] Run the pre-commit checks successfully.

Other information

<!-- Any other information that is important to this PR not covered earlier. -->

Adding reviewers:
@coremaker/devops